### PR TITLE
PlayStation 2 Controller Emulator Control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.0.3"
 dependencies = [
  "clap 2.26.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sdl2 0.27.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serial 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -59,6 +60,14 @@ dependencies = [
 name = "custom_derive"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ioctl-rs"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -172,6 +181,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serial-core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serial-unix 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serial-windows 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serial-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serial-unix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ioctl-rs 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serial-core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termios 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serial-windows"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serial-core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "strsim"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,6 +241,14 @@ dependencies = [
  "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termios"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -233,6 +288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum clap 2.26.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3451e409013178663435d6f15fdb212f14ee4424a3d74f979d081d0a66b6f1f2"
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 "checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
+"checksum ioctl-rs 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c733bd6be680c4365bfeb89ac48d4c39ee2c47d933da3601689131471aaf3267"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9e5e58fa1a4c3b915a561a78a22ee0cac6ab97dca2504428bc1cb074375f8d5"
 "checksum libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "d1419b2939a0bc44b77feb34661583c7546b532b192feab36249ab584b86856c"
@@ -247,9 +303,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum sdl2 0.27.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a6515df508d33b534d7ba76b278938d5777a081bc129d83a62a089cfb790eb84"
 "checksum sdl2-sys 0.27.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8d9f87e3d948f94f2d8688970422f49249c20e97f8f3aad76cb8729901d4eb10"
+"checksum serial 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
+"checksum serial-core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
+"checksum serial-unix 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
+"checksum serial-windows 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+"checksum termios 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
 "checksum textwrap 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df8e08afc40ae3459e4838f303e465aa50d823df8d7f83ca88108f6d3afe7edd"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ readme = "README.md"
 [dependencies]
 clap = "2.20.0"
 sdl2 = "0.27.2"
+serial = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,72 +21,7 @@ fn main() {
         .subcommand(SubCommand::with_name("test").about("Tests the game controller subsystem"))
         .get_matches();
 
-    match matches.subcommand_name() {
-        Some("test") => {
-            test();
-        }
-        Some("ps2ce") => {
-            let ps2ce_matches = matches.subcommand_matches("ps2ce").unwrap();
-            let device_path = ps2ce_matches.value_of("device").unwrap();
-            ps2ce(&device_path).unwrap();
-        }
-        _ => (),
-    }
-}
-
-fn ps2ce(device_path: &str) -> io::Result<()> {
-    println!("Connecting to PS2 Controller Emulator device at '{}'...", device_path);
-
-    let mut serial = match serial::open(device_path) {
-        Ok(serial) => serial,
-        Err(error) => panic!("failed to open serial device: {}", error)
-    };
-
-    try!(serial.reconfigure(&|settings| {
-        try!(settings.set_baud_rate(serial::Baud9600));
-        settings.set_char_size(serial::Bits8);
-        Ok(())
-    }));
-
-    println!("Connected!");
-    println!("Sending a command!");
-
-    let buf = vec!(
-        0x5A, // DualShock Magic
-
-        // Buttons (0=Pressed)
-        //┌─────────── Left
-        //│┌────────── Down
-        //││┌───────── Right
-        //│││┌──────── Up
-        //││││┌─────── [Start>
-        //│││││┌────── (R3)
-        //││││││┌───── (L3)
-        //│││││││┌──── [Select]
-        0b11111111u8,
-        0b11111111u8,
-        //│││││││└──── [L2]
-        //││││││└───── [R2]
-        //│││││└────── [L1]
-        //││││└─────── [R1]
-        //│││└──────── Triangle
-        //││└───────── Circle
-        //│└────────── Cross
-        //└─────────── Square
-
-        // Sticks
-        0x80, // Right stick X
-        0x80, // Right stick Y
-        0x80, // Left stick X
-        0x80, // Left stick Y
-    );
-
-    try!(serial.write(&buf[..]));
-
-    Ok(())
-}
-
-fn test() {
+    // Initialise SDL2, and the game controller subsystem
     let sdl_context = sdl2::init().unwrap();
     let game_controller_subsystem = sdl_context.game_controller().unwrap();
 
@@ -136,7 +71,83 @@ fn test() {
     println!("(There are {} controllers connected)",
              active_controllers.len());
 
-    // Listen to SDL events!
+    match matches.subcommand_name() {
+        Some("ps2ce") => {
+            let ps2ce_matches = matches.subcommand_matches("ps2ce").unwrap();
+            let device_path = ps2ce_matches.value_of("device").unwrap();
+
+            send_to_ps2_controller_emulator(&device_path,
+                                            sdl_context,
+                                            game_controller_subsystem,
+                                            &mut active_controllers).unwrap();
+        }
+        Some("test") => {
+            print_events(sdl_context,
+                         game_controller_subsystem,
+                         &mut active_controllers);
+        }
+        _ => (),
+    }
+}
+
+fn send_to_ps2_controller_emulator(device_path: &str,
+                                   sdl_context: sdl2::Sdl,
+                                   game_controller_subsystem: sdl2::GameControllerSubsystem,
+                                   active_controllers: &mut HashMap<i32, sdl2::controller::GameController>) -> io::Result<()> {
+    println!("Connecting to PS2 Controller Emulator device at '{}'...", device_path);
+
+    let mut serial = match serial::open(device_path) {
+        Ok(serial) => serial,
+        Err(error) => panic!("failed to open serial device: {}", error)
+    };
+
+    try!(serial.reconfigure(&|settings| {
+        try!(settings.set_baud_rate(serial::Baud9600));
+        settings.set_char_size(serial::Bits8);
+        Ok(())
+    }));
+
+    println!("Connected!");
+
+    let buf = vec!(
+        0x5A, // DualShock Magic
+
+        // Buttons (0=Pressed)
+        //┌─────────── Left
+        //│┌────────── Down
+        //││┌───────── Right
+        //│││┌──────── Up
+        //││││┌─────── [Start>
+        //│││││┌────── (R3)
+        //││││││┌───── (L3)
+        //│││││││┌──── [Select]
+        0b11111111u8,
+        0b11111111u8,
+        //│││││││└──── [L2]
+        //││││││└───── [R2]
+        //│││││└────── [L1]
+        //││││└─────── [R1]
+        //│││└──────── Triangle
+        //││└───────── Circle
+        //│└────────── Cross
+        //└─────────── Square
+
+        // Sticks
+        0x80, // Right stick X
+        0x80, // Right stick Y
+        0x80, // Left stick X
+        0x80, // Left stick Y
+    );
+
+    try!(serial.write(&buf[..]));
+
+    Ok(())
+}
+
+fn print_events(sdl_context: sdl2::Sdl,
+                game_controller_subsystem: sdl2::GameControllerSubsystem,
+                active_controllers: &mut HashMap<i32, sdl2::controller::GameController>) {
+    println!("Printing all controller events...");
     for event in sdl_context.event_pump().unwrap().wait_iter() {
         use sdl2::event::Event;
 
@@ -160,6 +171,21 @@ fn test() {
                 }
             }
 
+            Event::ControllerDeviceRemoved { which, .. } => {
+                println!("{} (#{}): disconnected",
+                         active_controllers[&which].name(),
+                         which);
+                println!("(There are {} controllers connected)",
+                         active_controllers.len() - 1);
+                active_controllers.remove(&which);
+            }
+
+            Event::ControllerDeviceRemapped { which, .. } => {
+                println!("{} (#{}) remapped!",
+                         active_controllers[&which].name(),
+                         which);
+            }
+
             Event::ControllerAxisMotion { which, axis, value, .. } => {
                 println!("{} (#{}): {:?}: {}",
                          active_controllers[&which].name(),
@@ -180,21 +206,6 @@ fn test() {
                          active_controllers[&which].name(),
                          which,
                          button);
-            }
-
-            Event::ControllerDeviceRemoved { which, .. } => {
-                println!("{} (#{}): disconnected",
-                         active_controllers[&which].name(),
-                         which);
-                println!("(There are {} controllers connected)",
-                         active_controllers.len() - 1);
-                active_controllers.remove(&which);
-            }
-
-            Event::ControllerDeviceRemapped { which, .. } => {
-                println!("{} (#{}) remapped!",
-                         active_controllers[&which].name(),
-                         which);
             }
 
             Event::Quit { .. } => break,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ static DUALSHOCK_MAGIC: u8 = 0x5A;
 enum ControllerEmulatorPacketType {
     None,       // Fallback, just log messages
     SevenByte,  // For Johnny Chung Lee's firmware
-    TwentyByte, // For pelvicthrustman's firmware
+    TwentyByte, // For Aaron Clovsky's firmware
 }
 
 fn main() {
@@ -285,7 +285,7 @@ fn send_to_ps2_controller_emulator(global_arguments: &clap::ArgMatches,
             if read == 0 {
                 communication_mode = ControllerEmulatorPacketType::TwentyByte;
                 if verbose {
-                    println!("No response. I suspect this is pelvicthrustman's work!");
+                    println!("No response. I suspect this is Aaron Clovsky's work!");
                 }
             } if response[0] == ('x' as u8) {
                 communication_mode = ControllerEmulatorPacketType::SevenByte;

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ fn main() {
                 .default_value("normal")
                 .possible_value("normal")
                 .possible_value("right-stick")
-                /*.possible_value("cross-and-square")*/))
+                .possible_value("cross-and-square")))
         .subcommand(clap::SubCommand::with_name("test").about("Tests the game controller subsystem"))
         .get_matches();
 
@@ -189,8 +189,8 @@ fn controller_map_seven_byte(controller: &sdl2::controller::GameController,
     let r1_button_value = convert_button(controller.button(sdl2::controller::Button::RightShoulder));
     let triangle_value = convert_button(controller.button(sdl2::controller::Button::Y));
     let circle_value = convert_button(controller.button(sdl2::controller::Button::B));
-    let cross_value = convert_button(controller.button(sdl2::controller::Button::A));
-    let square_value = convert_button(controller.button(sdl2::controller::Button::X));
+    let cross_value;
+    let square_value;
 
     let right_stick_x_value = convert_whole_axis(controller.axis(sdl2::controller::Axis::RightX)/*.saturating_mul(1.1)*/);
     let right_stick_y_value;
@@ -204,11 +204,26 @@ fn controller_map_seven_byte(controller: &sdl2::controller::GameController,
             l2_button_value = convert_half_axis_negative(raw_right_stick_y);
             r2_button_value = convert_half_axis_positive(raw_right_stick_y);
 
+            cross_value = convert_button(controller.button(sdl2::controller::Button::A));
+            square_value = convert_button(controller.button(sdl2::controller::Button::X));
+
             right_stick_y_value = combine_trigger_axes(raw_left_trigger, raw_right_trigger);
+        }
+        "cross-and-square" => {
+            l2_button_value = convert_button(controller.button(sdl2::controller::Button::A));
+            r2_button_value = convert_button(controller.button(sdl2::controller::Button::X));
+
+            cross_value = convert_half_axis_positive(raw_right_trigger);
+            square_value = convert_half_axis_positive(raw_left_trigger);
+
+            right_stick_y_value = convert_whole_axis(raw_right_stick_y/*.saturating_mul(1.1)*/);
         }
         _ => {
             l2_button_value = convert_half_axis_positive(raw_left_trigger);
             r2_button_value = convert_half_axis_positive(raw_right_trigger);
+
+            cross_value = convert_button(controller.button(sdl2::controller::Button::A));
+            square_value = convert_button(controller.button(sdl2::controller::Button::X));
 
             right_stick_y_value = convert_whole_axis(raw_right_stick_y/*.saturating_mul(1.1)*/);
         }


### PR DESCRIPTION
- [x] Add serial comms
- [x] Generalise SDL initialisation
- [x] Implement controller remapping
- [x] Support USB serial control signals for Johnny Chung Lee’s [Teensy PS2 Controller Sim Firmware](http://procrastineering.blogspot.ca/2010/12/simulated-ps2-controller-for.html) (tested with v2)