### PR TITLE
🎮 Genericise and mock out the core controller transliteration routines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+flame-graph.*

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,2 +1,1 @@
 reorder_imports = true
-write_mode = "Overwrite"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     # macOS
     - env: TARGET=x86_64-apple-darwin
       os: osx
-      rust: 1.24.0
+      rust: 1.32.0
 
     # macOS (Stable)
     - env: TARGET=x86_64-apple-darwin

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,7 @@ install:
   - source ~/.cargo/env || true
 
 before_script:
-  - rustup toolchain install nightly
-  - rustup component add --toolchain nightly rustfmt-preview
-  - which rustfmt || cargo install --force rustfmt-nightly
+  - rustup component add rustfmt
 
 script:
   - bash ci/script.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "flame"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread-id 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "float_duration"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +119,20 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itoa"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -190,6 +221,7 @@ name = "omnishock"
 version = "0.0.6"
 dependencies = [
  "clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flame 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "game_time 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-view 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -197,6 +229,11 @@ dependencies = [
  "serial 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin_sleep 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand"
@@ -263,6 +300,36 @@ version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "serde_derive"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_internals 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "serial"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +382,24 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,6 +426,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-id"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "time"
 version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,8 +451,18 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "vec_map"
 version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -368,6 +473,11 @@ dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -388,12 +498,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1c07b9257a00f3fc93b7f3c417fc15607ec7a56823bc2c37ec744e266387de5b"
+"checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
+"checksum flame 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ceb1856466a5f4ae30d66b835baf77cd82c1d91eda9bcc3b794fae8d462323b7"
 "checksum float_duration 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4aed8e3182af8f7f1227d88fe6203a83e7a0cff36a8f0af7195f11449217480e"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum game_time 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bbce5bdbbca9670a5551caecfe23cc352f30c270669653e7a1d9759b61535162"
 "checksum hex-view 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "71d52599ac1d8f67b4e6cf183d0235eec1ef5d68ec0348f10772bf71ecc4ee6e"
 "checksum ioctl-rs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
+"checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
@@ -404,6 +518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "4b226df12c5a59b63569dd57fafb926d91b385dfce33d8074a412411b689d593"
 "checksum num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
 "checksum num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7de20f146db9d920c45ee8ed8f71681fd9ade71909b48c3acbd766aa504cf10"
+"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
@@ -412,18 +527,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum sdl2 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a74c2a98a354b20713b90cce70aef9e927e46110d1bc4ef728fd74e0d53eba60"
 "checksum sdl2-sys 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c543ce8a6e33a30cb909612eeeb22e693848211a84558d5a00bb11e791b7ab7"
 "checksum serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "db99f3919e20faa51bb2996057f5031d8685019b5a06139b1ce761da671b8526"
+"checksum serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "f4ba7591cfe93755e89eeecdbcc668885624829b020050e6aec99c2a03bd3fd0"
+"checksum serde_derive_internals 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6e03f1c9530c3fb0a0a5c9b826bdd9246a5921ae995d75f512ac917fc4dd55b5"
+"checksum serde_json 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "57781ed845b8e742fc2bf306aba8e3b408fe8c366b900e3769fbc39f49eb8b39"
 "checksum serial 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
 "checksum serial-core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
 "checksum serial-unix 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
 "checksum serial-windows 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
 "checksum spin_sleep 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7cb4ed6de8cd2d4054f361b6dc45e57953c0063b9e31484d5eefadd4de79097b"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum termios 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
+"checksum thread-id 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2af4d6289a69a35c4d3aea737add39685f2784122c28119a7713165a63d68c9d"
 "checksum time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "a15375f1df02096fb3317256ce2cee6a1f42fc84ea5ad5fc8c421cfe40c73098"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
+"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,11 @@ version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "mockstream"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "num"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +229,7 @@ dependencies = [
  "flame 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "game_time 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-view 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mockstream 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "sdl2 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serial 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -511,6 +517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
+"checksum mockstream 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "35bbe0c0c9d254b463b13734bc361d1423289547e052b1e77e5a77292496ba2e"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 "checksum num-bigint 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "81b483ea42927c463e191802e7334556b48e7875297564c0e9951bd3a0ae53e3"
 "checksum num-complex 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "26ff8edeab9f1d8cf6b595e35138c2a389ea29f4f57a0e6bc44abf406e4b0077"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,13 @@ homepage = "https://github.com/ticky/omnishock"
 license = "GPL-3.0-or-later"
 readme = "README.md"
 
+[features]
+default = []
+flamegraph-profiling = ["flame"]
+
 [dependencies]
 clap = "2.30.0"
+flame = { version = "0.2.0", optional = true }
 game_time = "0.2.0"
 hex-view = "0.1.2"
 num = "0.1.42"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ sdl2 = "0.31.0"
 serial = "0.4"
 spin_sleep = "0.3.4"
 
+[dev-dependencies]
+mockstream = "0.0.3"
+
 [target.x86_64-unknown-linux-gnu]
 image = "sdl2-x86_64-unknown-linux-gnu"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 
 environment:
   global:
-    RUST_VERSION: 1.24.0
+    RUST_VERSION: 1.32.0
     CRATE_NAME: omnishock
 
   matrix:

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -10,7 +10,7 @@ main() {
     cross build --target $TARGET
     cross build --target $TARGET --release
 
-    cargo +nightly fmt --all -- --write-mode=diff
+    cargo fmt --all -- --check
 
     if [ ! -z $DISABLE_TESTS ]; then
         return

--- a/src/main.rs
+++ b/src/main.rs
@@ -975,7 +975,69 @@ mod tests {
             FauxController::create_with_name(String::from("Applejack Game-player Pad"));
 
         assert_eq!(
-            controller_map_twenty_byte(&controller, "", true),
+            controller_map_twenty_byte(&controller, "normal", true),
+            vec![
+                DUALSHOCK_MAGIC,
+                // buttons1
+                255,
+                // buttons2
+                255,
+                // Analog sticks
+                128,
+                128,
+                128,
+                128,
+                // Pressure values
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                // Mode footer
+                85,
+            ]
+        );
+
+        assert_eq!(
+            controller_map_twenty_byte(&controller, "right-stick", true),
+            vec![
+                DUALSHOCK_MAGIC,
+                // buttons1
+                255,
+                // buttons2
+                255,
+                // Analog sticks
+                128,
+                128,
+                128,
+                128,
+                // Pressure values
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                // Mode footer
+                85,
+            ]
+        );
+
+        assert_eq!(
+            controller_map_twenty_byte(&controller, "cross-and-square", true),
             vec![
                 DUALSHOCK_MAGIC,
                 // buttons1
@@ -1015,7 +1077,7 @@ mod tests {
         controller.set_axis(Axis::LeftY, -4_096);
 
         assert_eq!(
-            controller_map_twenty_byte(&controller, "", true),
+            controller_map_twenty_byte(&controller, "normal", true),
             vec![
                 DUALSHOCK_MAGIC,
                 // buttons1
@@ -1044,6 +1106,68 @@ mod tests {
                 85,
             ]
         );
+
+        assert_eq!(
+            controller_map_twenty_byte(&controller, "right-stick", true),
+            vec![
+                DUALSHOCK_MAGIC,
+                // buttons1
+                127,
+                // buttons2
+                189,
+                // Analog sticks
+                24,
+                255,
+                129,
+                110,
+                // Pressure values
+                0,
+                255,
+                0,
+                0,
+                0,
+                0,
+                255,
+                0,
+                0,
+                0,
+                0,
+                128,
+                // Mode footer
+                85,
+            ]
+        );
+
+        assert_eq!(
+            controller_map_twenty_byte(&controller, "cross-and-square", true),
+            vec![
+                DUALSHOCK_MAGIC,
+                // buttons1
+                127,
+                // buttons2
+                126,
+                // Analog sticks
+                24,
+                198,
+                129,
+                110,
+                // Pressure values
+                0,
+                255,
+                0,
+                0,
+                0,
+                0,
+                0,
+                255,
+                0,
+                0,
+                255,
+                0,
+                // Mode footer
+                85,
+            ]
+        );
     }
 
     #[test]
@@ -1056,7 +1180,39 @@ mod tests {
             FauxController::create_with_name(String::from("Apple Pippin Controller"));
 
         assert_eq!(
-            controller_map_seven_byte(&controller, "", true),
+            controller_map_seven_byte(&controller, "normal", true),
+            vec![
+                DUALSHOCK_MAGIC,
+                // buttons1
+                255,
+                // buttons2
+                255,
+                // Analog sticks
+                128,
+                128,
+                128,
+                128,
+            ]
+        );
+
+        assert_eq!(
+            controller_map_seven_byte(&controller, "right-stick", true),
+            vec![
+                DUALSHOCK_MAGIC,
+                // buttons1
+                255,
+                // buttons2
+                255,
+                // Analog sticks
+                128,
+                128,
+                128,
+                128,
+            ]
+        );
+
+        assert_eq!(
+            controller_map_seven_byte(&controller, "cross-and-square", true),
             vec![
                 DUALSHOCK_MAGIC,
                 // buttons1
@@ -1081,13 +1237,45 @@ mod tests {
         controller.set_axis(Axis::LeftY, -4_096);
 
         assert_eq!(
-            controller_map_seven_byte(&controller, "", true),
+            controller_map_seven_byte(&controller, "normal", true),
             vec![
                 DUALSHOCK_MAGIC,
                 // buttons1
                 127,
                 // buttons2
                 190,
+                // Analog sticks
+                24,
+                198,
+                129,
+                110,
+            ]
+        );
+
+        assert_eq!(
+            controller_map_seven_byte(&controller, "right-stick", true),
+            vec![
+                DUALSHOCK_MAGIC,
+                // buttons1
+                127,
+                // buttons2
+                189,
+                // Analog sticks
+                24,
+                255,
+                129,
+                110,
+            ]
+        );
+
+        assert_eq!(
+            controller_map_seven_byte(&controller, "cross-and-square", true),
+            vec![
+                DUALSHOCK_MAGIC,
+                // buttons1
+                127,
+                // buttons2
+                126,
                 // Analog sticks
                 24,
                 198,

--- a/src/main.rs
+++ b/src/main.rs
@@ -633,6 +633,8 @@ fn send_to_ps2_controller_emulator_via<I: Read + Write>(
                 // If we've receieved a response from the controller, and our
                 // controller supports haptic feedback, update its haptic state
                 if !response.is_empty() {
+                    let controller_name = controller_manager.name();
+
                     match controller_manager.haptic {
                         Some(ref mut haptic) => {
                             let small_motor_intensity = response[1];
@@ -647,7 +649,7 @@ fn send_to_ps2_controller_emulator_via<I: Read + Write>(
                                 println!(
                                     "Setting haptic feedback to {} for {}",
                                     rumble_intensity,
-                                    controller_manager.controller.name()
+                                    controller_name
                                 );
                             }
 
@@ -786,23 +788,27 @@ fn print_events(_arguments: &clap::ArgMatches, sdl_manager: &mut SDLManager) {
             } => {
                 println!(
                     "“{}” (#{}): {:?}: {}",
-                    sdl_manager.active_controllers[&which].controller.name(),
+                    sdl_manager.active_controllers[&which].name(),
                     which,
                     axis,
                     value
                 );
 
                 match sdl_manager.active_controllers.get_mut(&which) {
-                    Some(controller_manager) => match controller_manager.haptic {
-                        Some(ref mut haptic) => {
-                            println!(
-                                "Running haptic feedback for “{}”",
-                                controller_manager.controller.name()
-                            );
-                            haptic.rumble_stop();
-                            haptic.rumble_play(1.0, 500);
+                    Some(controller_manager) => {
+                        let controller_name = controller_manager.name();
+
+                        match controller_manager.haptic {
+                            Some(ref mut haptic) => {
+                                println!(
+                                    "Running haptic feedback for “{}”",
+                                    controller_name
+                                );
+                                haptic.rumble_stop();
+                                haptic.rumble_play(1.0, 500);
+                            }
+                            _ => (),
                         }
-                        _ => (),
                     },
                     _ => (),
                 };
@@ -811,7 +817,7 @@ fn print_events(_arguments: &clap::ArgMatches, sdl_manager: &mut SDLManager) {
             Event::ControllerButtonDown { which, button, .. } => {
                 println!(
                     "“{}” (#{}): {:?}: down",
-                    sdl_manager.active_controllers[&which].controller.name(),
+                    sdl_manager.active_controllers[&which].name(),
                     which,
                     button
                 );
@@ -820,7 +826,7 @@ fn print_events(_arguments: &clap::ArgMatches, sdl_manager: &mut SDLManager) {
             Event::ControllerButtonUp { which, button, .. } => {
                 println!(
                     "“{}” (#{}): {:?}: up",
-                    sdl_manager.active_controllers[&which].controller.name(),
+                    sdl_manager.active_controllers[&which].name(),
                     which,
                     button
                 );

--- a/src/main.rs
+++ b/src/main.rs
@@ -942,10 +942,6 @@ mod tests {
             return new_controller;
         }
 
-        fn set_name(&mut self, name: String) {
-            self.name = name;
-        }
-
         fn set_button(&mut self, button: sdl2::controller::Button, value: bool) {
             self.buttons.insert(button, value);
         }
@@ -973,12 +969,13 @@ mod tests {
     fn controller_map_twenty_byte_works() {
         use DUALSHOCK_MAGIC;
         use super::controller_map_twenty_byte;
+        use sdl2::controller::{Axis, Button};
 
-        let neutral_controller =
-            FauxController::create_with_name(String::from("Neutral Controller"));
+        let mut controller =
+            FauxController::create_with_name(String::from("Applejack Game-player Pad"));
 
         assert_eq!(
-            controller_map_twenty_byte(&neutral_controller, "", true),
+            controller_map_twenty_byte(&controller, "", true),
             vec![
                 DUALSHOCK_MAGIC,
                 // buttons1
@@ -1007,18 +1004,59 @@ mod tests {
                 85,
             ]
         );
+
+        // Do some stuff to the controller state, and test again
+        controller.set_button(Button::DPadLeft, true);
+        controller.set_button(Button::A, true);
+        controller.set_axis(Axis::TriggerLeft, i16::max_value());
+        controller.set_axis(Axis::RightX, -24_000);
+        controller.set_axis(Axis::RightY, 16_500);
+        controller.set_axis(Axis::LeftX, 255);
+        controller.set_axis(Axis::LeftY, -4_096);
+
+        assert_eq!(
+            controller_map_twenty_byte(&controller, "", true),
+            vec![
+                DUALSHOCK_MAGIC,
+                // buttons1
+                127,
+                // buttons2
+                190,
+                // Analog sticks
+                24,
+                198,
+                129,
+                110,
+                // Pressure values
+                0,
+                255,
+                0,
+                0,
+                0,
+                0,
+                255,
+                0,
+                0,
+                0,
+                255,
+                0,
+                // Mode footer
+                85,
+            ]
+        );
     }
 
     #[test]
     fn controller_map_seven_byte_works() {
         use DUALSHOCK_MAGIC;
         use super::controller_map_seven_byte;
+        use sdl2::controller::{Axis, Button};
 
-        let neutral_controller =
-            FauxController::create_with_name(String::from("Neutral Controller"));
+        let mut controller =
+            FauxController::create_with_name(String::from("Apple Pippin Controller"));
 
         assert_eq!(
-            controller_map_seven_byte(&neutral_controller, "", true),
+            controller_map_seven_byte(&controller, "", true),
             vec![
                 DUALSHOCK_MAGIC,
                 // buttons1
@@ -1030,6 +1068,31 @@ mod tests {
                 128,
                 128,
                 128,
+            ]
+        );
+
+        // Do some stuff to the controller state, and test again
+        controller.set_button(Button::DPadLeft, true);
+        controller.set_button(Button::A, true);
+        controller.set_axis(Axis::TriggerLeft, i16::max_value());
+        controller.set_axis(Axis::RightX, -24_000);
+        controller.set_axis(Axis::RightY, 16_500);
+        controller.set_axis(Axis::LeftX, 255);
+        controller.set_axis(Axis::LeftY, -4_096);
+
+        assert_eq!(
+            controller_map_seven_byte(&controller, "", true),
+            vec![
+                DUALSHOCK_MAGIC,
+                // buttons1
+                127,
+                // buttons2
+                190,
+                // Analog sticks
+                24,
+                198,
+                129,
+                110,
             ]
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -588,8 +588,8 @@ fn send_to_ps2_controller_emulator_via<I: Read + Write>(
     // We use `game_time` to keep track of "frame" time and try to hit a
     // consistent rate at all times. We use `spin_sleep` instead of
     // `thread::Sleep` to get more accurate sleep times on all platforms.
-    use game_time::{FloatDuration, FrameCount, FrameCounter, GameClock};
     use game_time::framerate::RunningAverageSampler;
+    use game_time::{FloatDuration, FrameCount, FrameCounter, GameClock};
 
     let mut clock = GameClock::new();
     let mut counter = FrameCounter::new(60.0, RunningAverageSampler::with_max_samples(60));
@@ -1071,8 +1071,8 @@ mod tests {
     #[test]
     fn controller_map_twenty_byte_works() {
         use super::controller_map_twenty_byte;
-        use DUALSHOCK_MAGIC;
         use sdl2::controller::{Axis, Button};
+        use DUALSHOCK_MAGIC;
 
         let mut controller =
             FauxController::create_with_name(String::from("Applejack Game-player Pad"));
@@ -1276,8 +1276,8 @@ mod tests {
     #[test]
     fn controller_map_seven_byte_works() {
         use super::controller_map_seven_byte;
-        use DUALSHOCK_MAGIC;
         use sdl2::controller::{Axis, Button};
+        use DUALSHOCK_MAGIC;
 
         let mut controller =
             FauxController::create_with_name(String::from("Apple Pippin Controller"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -920,8 +920,8 @@ mod tests {
     }
 
     use sdl2;
-    use std::collections::HashMap;
     use sdl_manager::Gamepad;
+    use std::collections::HashMap;
 
     struct FauxController {
         name: String,
@@ -967,8 +967,8 @@ mod tests {
 
     #[test]
     fn controller_map_twenty_byte_works() {
-        use DUALSHOCK_MAGIC;
         use super::controller_map_twenty_byte;
+        use DUALSHOCK_MAGIC;
         use sdl2::controller::{Axis, Button};
 
         let mut controller =
@@ -1172,8 +1172,8 @@ mod tests {
 
     #[test]
     fn controller_map_seven_byte_works() {
-        use DUALSHOCK_MAGIC;
         use super::controller_map_seven_byte;
+        use DUALSHOCK_MAGIC;
         use sdl2::controller::{Axis, Button};
 
         let mut controller =

--- a/src/main.rs
+++ b/src/main.rs
@@ -740,9 +740,9 @@ fn send_to_ps2_controller_emulator_via<I: Read + Write>(
     Ok(())
 }
 
-fn send_event_to_controller<I: Read + Write>(
+fn send_event_to_controller<I: Read + Write, T: Gamepad>(
     serial: &mut I,
-    controller_manager: &sdl_manager::ControllerManager,
+    controller_manager: &T,
     communication_mode: &ControllerEmulatorPacketType,
     trigger_mode: &str,
     normalise_sticks: bool,
@@ -939,6 +939,8 @@ fn print_events(_arguments: &clap::ArgMatches, sdl_manager: &mut SDLManager) {
 
 #[cfg(test)]
 mod tests {
+    extern crate mockstream;
+
     #[test]
     fn collapse_bits_works() {
         use super::collapse_bits;
@@ -1082,29 +1084,29 @@ mod tests {
             vec![
                 DUALSHOCK_MAGIC,
                 // buttons1
-                255,
+                0b11111111u8,
                 // buttons2
-                255,
+                0b11111111u8,
                 // Analog sticks
-                128,
-                128,
-                128,
-                128,
+                0x80,
+                0x80,
+                0x80,
+                0x80,
                 // Pressure values
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
                 // Mode footer
-                85,
+                0x55,
             ]
         );
 
@@ -1113,29 +1115,29 @@ mod tests {
             vec![
                 DUALSHOCK_MAGIC,
                 // buttons1
-                255,
+                0b11111111u8,
                 // buttons2
-                255,
+                0b11111111u8,
                 // Analog sticks
-                128,
-                128,
-                128,
-                128,
+                0x80,
+                0x80,
+                0x80,
+                0x80,
                 // Pressure values
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
                 // Mode footer
-                85,
+                0x55,
             ]
         );
 
@@ -1144,29 +1146,29 @@ mod tests {
             vec![
                 DUALSHOCK_MAGIC,
                 // buttons1
-                255,
+                0b11111111u8,
                 // buttons2
-                255,
+                0b11111111u8,
                 // Analog sticks
-                128,
-                128,
-                128,
-                128,
+                0x80,
+                0x80,
+                0x80,
+                0x80,
                 // Pressure values
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
                 // Mode footer
-                85,
+                0x55,
             ]
         );
 
@@ -1184,29 +1186,29 @@ mod tests {
             vec![
                 DUALSHOCK_MAGIC,
                 // buttons1
-                127,
+                0b01111111u8,
                 // buttons2
-                190,
+                0b10111110u8,
                 // Analog sticks
-                24,
-                198,
-                129,
-                110,
+                0x18,
+                0xC6,
+                0x81,
+                0x6E,
                 // Pressure values
-                0,
-                255,
-                0,
-                0,
-                0,
-                0,
-                255,
-                0,
-                0,
-                0,
-                255,
-                0,
+                0x00,
+                0xFF,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0xFF,
+                0x00,
+                0x00,
+                0x00,
+                0xFF,
+                0x00,
                 // Mode footer
-                85,
+                0x55,
             ]
         );
 
@@ -1215,29 +1217,29 @@ mod tests {
             vec![
                 DUALSHOCK_MAGIC,
                 // buttons1
-                127,
+                0b01111111u8,
                 // buttons2
-                189,
+                0b10111101u8,
                 // Analog sticks
-                24,
-                255,
-                129,
-                110,
+                0x18,
+                0xFF,
+                0x81,
+                0x6E,
                 // Pressure values
-                0,
-                255,
-                0,
-                0,
-                0,
-                0,
-                255,
-                0,
-                0,
-                0,
-                0,
-                128,
+                0x00,
+                0xFF,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0xFF,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x80,
                 // Mode footer
-                85,
+                0x55,
             ]
         );
 
@@ -1246,29 +1248,29 @@ mod tests {
             vec![
                 DUALSHOCK_MAGIC,
                 // buttons1
-                127,
+                0b01111111u8,
                 // buttons2
-                126,
+                0b01111110u8,
                 // Analog sticks
-                24,
-                198,
-                129,
-                110,
+                0x18,
+                0xC6,
+                0x81,
+                0x6E,
                 // Pressure values
-                0,
-                255,
-                0,
-                0,
-                0,
-                0,
-                0,
-                255,
-                0,
-                0,
-                255,
-                0,
+                0x00,
+                0xFF,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0xFF,
+                0x00,
+                0x00,
+                0xFF,
+                0x00,
                 // Mode footer
-                85,
+                0x55,
             ]
         );
     }
@@ -1287,14 +1289,14 @@ mod tests {
             vec![
                 DUALSHOCK_MAGIC,
                 // buttons1
-                255,
+                0b11111111u8,
                 // buttons2
-                255,
+                0b11111111u8,
                 // Analog sticks
-                128,
-                128,
-                128,
-                128,
+                0x80,
+                0x80,
+                0x80,
+                0x80,
             ]
         );
 
@@ -1303,14 +1305,14 @@ mod tests {
             vec![
                 DUALSHOCK_MAGIC,
                 // buttons1
-                255,
+                0b11111111u8,
                 // buttons2
-                255,
+                0b11111111u8,
                 // Analog sticks
-                128,
-                128,
-                128,
-                128,
+                0x80,
+                0x80,
+                0x80,
+                0x80,
             ]
         );
 
@@ -1319,14 +1321,14 @@ mod tests {
             vec![
                 DUALSHOCK_MAGIC,
                 // buttons1
-                255,
+                0b11111111u8,
                 // buttons2
-                255,
+                0b11111111u8,
                 // Analog sticks
-                128,
-                128,
-                128,
-                128,
+                0x80,
+                0x80,
+                0x80,
+                0x80,
             ]
         );
 
@@ -1344,14 +1346,14 @@ mod tests {
             vec![
                 DUALSHOCK_MAGIC,
                 // buttons1
-                127,
+                0b01111111u8,
                 // buttons2
-                190,
+                0b10111110u8,
                 // Analog sticks
-                24,
-                198,
-                129,
-                110,
+                0x18,
+                0xC6,
+                0x81,
+                0x6E,
             ]
         );
 
@@ -1360,14 +1362,14 @@ mod tests {
             vec![
                 DUALSHOCK_MAGIC,
                 // buttons1
-                127,
+                0b01111111u8,
                 // buttons2
-                189,
+                0b10111101u8,
                 // Analog sticks
-                24,
-                255,
-                129,
-                110,
+                0x18,
+                0xFF,
+                0x81,
+                0x6E,
             ]
         );
 
@@ -1376,14 +1378,106 @@ mod tests {
             vec![
                 DUALSHOCK_MAGIC,
                 // buttons1
-                127,
+                0b01111111u8,
                 // buttons2
-                126,
+                0b01111110u8,
                 // Analog sticks
-                24,
-                198,
-                129,
-                110,
+                0x18,
+                0xC6,
+                0x81,
+                0x6E,
+            ]
+        );
+    }
+
+    #[test]
+    fn send_event_to_controller_works() {
+        use self::mockstream::SharedMockStream;
+        use super::send_event_to_controller;
+        use super::ControllerEmulatorPacketType;
+        use DUALSHOCK_MAGIC;
+        use SEVEN_BYTE_OK_RESPONSE;
+        use TWENTY_BYTE_OK_HEADER;
+
+        let controller = FauxController::create_with_name(String::from("Apple Pippin Controller"));
+
+        let seven_byte_console_response = vec![SEVEN_BYTE_OK_RESPONSE as u8];
+
+        let mut serial = SharedMockStream::new();
+        serial.push_bytes_to_read(&seven_byte_console_response);
+
+        assert_eq!(
+            send_event_to_controller(
+                &mut serial,
+                &controller,
+                &ControllerEmulatorPacketType::SevenByte,
+                "normal",
+                false,
+                false,
+            )
+            .unwrap(),
+            seven_byte_console_response
+        );
+        assert_eq!(
+            serial.pop_bytes_written(),
+            vec![
+                DUALSHOCK_MAGIC,
+                // buttons1
+                0b11111111u8,
+                // buttons2
+                0b11111111u8,
+                // Analog sticks
+                0x80,
+                0x80,
+                0x80,
+                0x80,
+            ]
+        );
+
+        let twenty_byte_console_response = vec![TWENTY_BYTE_OK_HEADER, 0x00, 0x00];
+
+        serial.push_bytes_to_read(&twenty_byte_console_response);
+
+        assert_eq!(
+            send_event_to_controller(
+                &mut serial,
+                &controller,
+                &ControllerEmulatorPacketType::TwentyByte,
+                "normal",
+                false,
+                false,
+            )
+            .unwrap(),
+            twenty_byte_console_response
+        );
+        assert_eq!(
+            serial.pop_bytes_written(),
+            vec![
+                DUALSHOCK_MAGIC,
+                // buttons1
+                0b11111111u8,
+                // buttons2
+                0b11111111u8,
+                // Analog sticks
+                0x80,
+                0x80,
+                0x80,
+                0x80,
+                // Pressure values
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                // Mode footer
+                0x55,
             ]
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -645,7 +645,9 @@ fn send_to_ps2_controller_emulator_via<I: Read + Write>(
             match event {
                 Event::ControllerDeviceAdded { which, .. } => {
                     #[cfg(feature = "flamegraph-profiling")]
-                    let _guard = flame::start_guard("send_to_ps2_controller_emulator_via() Event::ControllerDeviceAdded");
+                    let _guard = flame::start_guard(
+                        "send_to_ps2_controller_emulator_via() Event::ControllerDeviceAdded",
+                    );
                     if !sdl_manager.has_controller(which).ok().unwrap_or(true) {
                         match sdl_manager.add_controller(which) {
                             Ok(_) => {
@@ -664,7 +666,9 @@ fn send_to_ps2_controller_emulator_via<I: Read + Write>(
 
                 Event::ControllerDeviceRemoved { which, .. } => {
                     #[cfg(feature = "flamegraph-profiling")]
-                    let _guard = flame::start_guard("send_to_ps2_controller_emulator_via() Event::ControllerDeviceRemoved");
+                    let _guard = flame::start_guard(
+                        "send_to_ps2_controller_emulator_via() Event::ControllerDeviceRemoved",
+                    );
                     match sdl_manager.remove_controller(which) {
                         Some(_) => {
                             println!(
@@ -877,7 +881,9 @@ fn print_events(_arguments: &clap::ArgMatches, sdl_manager: &mut SDLManager) {
                         match controller_manager.haptic {
                             Some(ref mut haptic) => {
                                 #[cfg(feature = "flamegraph-profiling")]
-                                let _guard = flame::start_guard("print_events Event::ControllerAxisMotion haptic");
+                                let _guard = flame::start_guard(
+                                    "print_events Event::ControllerAxisMotion haptic",
+                                );
                                 println!("Running haptic feedback for “{}”", controller_name);
                                 haptic.rumble_stop();
                                 haptic.rumble_play(1.0, 500);

--- a/src/sdl_manager.rs
+++ b/src/sdl_manager.rs
@@ -68,7 +68,7 @@ impl SDLManager {
         // Initialise SDL2, plus the video, haptic & game controller subsystems
         let context = {
             #[cfg(feature = "flamegraph-profiling")]
-            let _guard = flame::start_guard("SDLManager::init() sdl2::init().unwrap()");
+            let _guard = flame::start_guard("initialise sdl2 core");
             sdl2::init().unwrap()
         };
         /* NOTE: The video subsystem is not currently used, except for the side
@@ -77,7 +77,7 @@ impl SDLManager {
          *       in future. */
         let video_subsystem = {
             #[cfg(feature = "flamegraph-profiling")]
-            let _guard = flame::start_guard("SDLManager::init() video subsystem");
+            let _guard = flame::start_guard("initialise video subsystem");
             match context.video() {
                 Ok(video) => Some(video),
                 Err(error) => {
@@ -88,13 +88,12 @@ impl SDLManager {
         };
         let haptic_subsystem = {
             #[cfg(feature = "flamegraph-profiling")]
-            let _guard = flame::start_guard("SDLManager::init() haptic subsystem");
+            let _guard = flame::start_guard("initialise haptic subsystem");
             context.haptic().unwrap()
         };
         let game_controller_subsystem = {
             #[cfg(feature = "flamegraph-profiling")]
-            let _guard =
-                flame::start_guard("SDLManager::init() controller subsystem initialisation");
+            let _guard = flame::start_guard("initialise controller subsystem");
             context.game_controller().unwrap()
         };
 
@@ -110,7 +109,7 @@ impl SDLManager {
         };
 
         #[cfg(feature = "flamegraph-profiling")]
-        flame::start("SDLManager::init() import controller mappings");
+        flame::start("import controller mappings");
         // Load pre-set controller mappings (note that SDL will still read
         // others from the SDL_GAMECONTROLLERCONFIG environment variable)
         let controller_mappings = include_str!(
@@ -129,7 +128,7 @@ impl SDLManager {
             }
         }
         #[cfg(feature = "flamegraph-profiling")]
-        flame::end("SDLManager::init() import controller mappings");
+        flame::end("import controller mappings");
 
         // Look into controllers that were already connected at start-up
         sdl_manager.add_available_controllers();

--- a/src/sdl_manager.rs
+++ b/src/sdl_manager.rs
@@ -21,6 +21,9 @@
 extern crate sdl2;
 use std::collections::HashMap;
 
+#[cfg(feature = "flamegraph-profiling")]
+extern crate flame;
+
 // SDL Manager
 // Structure for passing around access to the SDL Subsystems,
 // and central place for setting up defaults
@@ -60,21 +63,39 @@ pub struct SDLManager {
 
 impl SDLManager {
     pub fn init() -> SDLManager {
+        #[cfg(feature = "flamegraph-profiling")]
+        let _guard = flame::start_guard("SDLManager::init()");
         // Initialise SDL2, plus the video, haptic & game controller subsystems
-        let context = sdl2::init().unwrap();
+        let context = {
+            #[cfg(feature = "flamegraph-profiling")]
+            let _guard = flame::start_guard("SDLManager::init() sdl2::init().unwrap()");
+            sdl2::init().unwrap()
+        };
         /* NOTE: The video subsystem is not currently used, except for the side
          *       effect that it prevents the system from triggering the screen
          *       saver. It will, however, be used to provide a window for focus
          *       in future. */
-        let video_subsystem = match context.video() {
-            Ok(video) => Some(video),
-            Err(error) => {
-                println!("couldn't initialise video: {}", error);
-                None
+        let video_subsystem = {
+            #[cfg(feature = "flamegraph-profiling")]
+            let _guard = flame::start_guard("SDLManager::init() video subsystem");
+            match context.video() {
+                Ok(video) => Some(video),
+                Err(error) => {
+                    println!("couldn't initialise video: {}", error);
+                    None
+                }
             }
         };
-        let haptic_subsystem = context.haptic().unwrap();
-        let game_controller_subsystem = context.game_controller().unwrap();
+        let haptic_subsystem = {
+            #[cfg(feature = "flamegraph-profiling")]
+            let _guard = flame::start_guard("SDLManager::init() haptic subsystem");
+            context.haptic().unwrap()
+        };
+        let game_controller_subsystem = {
+            #[cfg(feature = "flamegraph-profiling")]
+            let _guard = flame::start_guard("SDLManager::init() controller subsystem initialisation");
+            context.game_controller().unwrap()
+        };
 
         // Keep track of the controllers we know of
         let active_controllers: HashMap<i32, ControllerManager> = HashMap::new();
@@ -87,6 +108,8 @@ impl SDLManager {
             active_controllers,
         };
 
+        #[cfg(feature = "flamegraph-profiling")]
+        flame::start("SDLManager::init() import controller mappings");
         // Load pre-set controller mappings (note that SDL will still read
         // others from the SDL_GAMECONTROLLERCONFIG environment variable)
         let controller_mappings = include_str!(
@@ -104,6 +127,8 @@ impl SDLManager {
                 _ => (),
             }
         }
+        #[cfg(feature = "flamegraph-profiling")]
+        flame::end("SDLManager::init() import controller mappings");
 
         // Look into controllers that were already connected at start-up
         sdl_manager.add_available_controllers();
@@ -112,6 +137,8 @@ impl SDLManager {
     }
 
     fn add_available_controllers(&mut self) {
+        #[cfg(feature = "flamegraph-profiling")]
+        let _guard = flame::start_guard("SDLManager#add_available_controllers()");
         let joystick_count = match self.game_controller_subsystem.num_joysticks() {
             Ok(count) => count,
             Err(error) => panic!("failed to enumerate joysticks: {}", error),
@@ -137,6 +164,8 @@ impl SDLManager {
     }
 
     fn insert_controller(&mut self, index: u32) -> Result<i32, sdl2::IntegerOrSdlError> {
+        #[cfg(feature = "flamegraph-profiling")]
+        let _guard = flame::start_guard("SDLManager#insert_controller()");
         let controller = self.game_controller_subsystem.open(index)?;
         let haptic = self.haptic_subsystem.open_from_joystick_id(index).ok();
         let controller_id = controller.instance_id();
@@ -160,6 +189,8 @@ impl SDLManager {
     }
 
     pub fn add_controller(&mut self, index: u32) -> Result<i32, sdl2::IntegerOrSdlError> {
+        #[cfg(feature = "flamegraph-profiling")]
+        let _guard = flame::start_guard("SDLManager#add_controller()");
         let controller = self.game_controller_subsystem.open(index)?;
         let controller_id = controller.instance_id();
 
@@ -179,12 +210,16 @@ impl SDLManager {
     }
 
     pub fn has_controller(&self, index: u32) -> Result<bool, sdl2::IntegerOrSdlError> {
+        #[cfg(feature = "flamegraph-profiling")]
+        let _guard = flame::start_guard("SDLManager#has_controller()");
         let controller = self.game_controller_subsystem.open(index)?;
         return Ok(self.active_controllers
             .contains_key(&controller.instance_id()));
     }
 
     pub fn remove_controller(&mut self, id: i32) -> Option<ControllerManager> {
+        #[cfg(feature = "flamegraph-profiling")]
+        let _guard = flame::start_guard("SDLManager#remove_controller()");
         return match self.active_controllers.remove(&id) {
             Some(controller_manager) => {
                 println!(

--- a/src/sdl_manager.rs
+++ b/src/sdl_manager.rs
@@ -93,7 +93,8 @@ impl SDLManager {
         };
         let game_controller_subsystem = {
             #[cfg(feature = "flamegraph-profiling")]
-            let _guard = flame::start_guard("SDLManager::init() controller subsystem initialisation");
+            let _guard =
+                flame::start_guard("SDLManager::init() controller subsystem initialisation");
             context.game_controller().unwrap()
         };
 

--- a/src/sdl_manager.rs
+++ b/src/sdl_manager.rs
@@ -25,9 +25,24 @@ use std::collections::HashMap;
 // Structure for passing around access to the SDL Subsystems,
 // and central place for setting up defaults
 
+pub trait Gamepad {
+    fn button(&self, button: sdl2::controller::Button) -> bool;
+    fn axis(&self, axis: sdl2::controller::Axis) -> i16;
+}
+
 pub struct ControllerManager {
     pub controller: sdl2::controller::GameController,
     pub haptic: Option<sdl2::haptic::Haptic>,
+}
+
+impl Gamepad for ControllerManager {
+    fn button(&self, button: sdl2::controller::Button) -> bool {
+        self.controller.button(button)
+    }
+
+    fn axis(&self, axis: sdl2::controller::Axis) -> i16 {
+        self.controller.axis(axis)
+    }
 }
 
 pub struct SDLManager {

--- a/src/sdl_manager.rs
+++ b/src/sdl_manager.rs
@@ -28,7 +28,7 @@ extern crate flame;
 // Structure for passing around access to the SDL Subsystems,
 // and central place for setting up defaults
 
-pub trait Gamepad {
+pub trait GameController {
     fn name(&self) -> String;
     fn button(&self, button: sdl2::controller::Button) -> bool;
     fn axis(&self, axis: sdl2::controller::Axis) -> i16;
@@ -39,7 +39,7 @@ pub struct ControllerManager {
     pub haptic: Option<sdl2::haptic::Haptic>,
 }
 
-impl Gamepad for ControllerManager {
+impl GameController for ControllerManager {
     fn name(&self) -> String {
         self.controller.name()
     }

--- a/src/sdl_manager.rs
+++ b/src/sdl_manager.rs
@@ -112,11 +112,11 @@ impl SDLManager {
         flame::start("import controller mappings");
         // Load pre-set controller mappings (note that SDL will still read
         // others from the SDL_GAMECONTROLLERCONFIG environment variable)
-        let controller_mappings = include_str!(
-            "../vendor/SDL_GameControllerDB/gamecontrollerdb.txt"
-        ).lines()
-            .map(|line| line.trim())
-            .filter(|line| !line.is_empty() && !line.starts_with('#'));
+        let controller_mappings =
+            include_str!("../vendor/SDL_GameControllerDB/gamecontrollerdb.txt")
+                .lines()
+                .map(|line| line.trim())
+                .filter(|line| !line.is_empty() && !line.starts_with('#'));
 
         // Load each mapping individually rather than using load_mappings,
         // as it turns out doing them together can break without warning
@@ -213,7 +213,8 @@ impl SDLManager {
         #[cfg(feature = "flamegraph-profiling")]
         let _guard = flame::start_guard("SDLManager#has_controller()");
         let controller = self.game_controller_subsystem.open(index)?;
-        return Ok(self.active_controllers
+        return Ok(self
+            .active_controllers
             .contains_key(&controller.instance_id()));
     }
 

--- a/src/sdl_manager.rs
+++ b/src/sdl_manager.rs
@@ -26,16 +26,21 @@ use std::collections::HashMap;
 // and central place for setting up defaults
 
 pub trait Gamepad {
+    fn name(&self) -> String;
     fn button(&self, button: sdl2::controller::Button) -> bool;
     fn axis(&self, axis: sdl2::controller::Axis) -> i16;
 }
 
 pub struct ControllerManager {
-    pub controller: sdl2::controller::GameController,
+    controller: sdl2::controller::GameController,
     pub haptic: Option<sdl2::haptic::Haptic>,
 }
 
 impl Gamepad for ControllerManager {
+    fn name(&self) -> String {
+        self.controller.name()
+    }
+
     fn button(&self, button: sdl2::controller::Button) -> bool {
         self.controller.button(button)
     }


### PR DESCRIPTION
- [x] Swap from using an SDL `GameController` reference to a newly-defined Gamepad trait which exposes its inputs
- [ ] **BONUS POINTS**: Replace use of the `sdl2::controller::{Button, Axis}` with a locally shadowed implementation which can handle both
- [x] Implement a `T: Read + Write` buffer for testing which behaves like the serial port and can be set to return mocked data for particular inputs
- [x] Write tests which exercise the bits affected by these two:
  - [x] `fn controller_map_twenty_byte`
  - [x] `fn controller_map_seven_byte`
  - [x] `fn send_event_to_controller`

fixes #15